### PR TITLE
Run base_unittests

### DIFF
--- a/.github/workflows/base_unittests.yml
+++ b/.github/workflows/base_unittests.yml
@@ -1,0 +1,37 @@
+name: Base Unit Tests
+run-name: Base Unit Tests
+on:
+  workflow_call:
+    inputs:
+      build-mode:
+        required: true
+        type: string
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  SRC_DIR: /home/kxxt/chromium-ci/src
+  OUT_DIR: /home/kxxt/chromium-ci/src/out/${{ inputs.build-mode }}-riscv64
+
+jobs:
+  test:
+    runs-on: rvv-incapable
+    steps:
+      - name: test
+        run: |
+            set -ex
+            cd "$OUT_DIR"
+            ./base_unittests \
+                --test-launcher-jobs=48 \
+                --test-launcher-retry-limit=5 \
+                --test-launcher-timeout=60000 \
+                --gtest_filter=-"\
+                    `# Expected failure for now`\
+                    SysInfoTest.GetHardwareInfo:\
+                    `# TODO: the following failures look serious`\
+                    StackTraceTest.TraceStackFramePointers:\
+                    `# TODO: the following failures might worth investigation. Flaky`\
+                    All/SingleThreadTaskExecutorTypedTest.RecursivePostsDoNotFloodPipe/default_pump:\
+                    All/SingleThreadTaskExecutorTypedTest.RecursivePostsDoNotFloodPipe/UI_pump:\
+                    All/SingleThreadTaskExecutorTypedTest.RecursivePostsDoNotFloodPipe/default_pump:\
+                    All/SingleThreadTaskExecutorTypedTest.RecursivePostsDoNotFloodPipe/IO_pump
+                "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 run-name: CI
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -40,6 +41,9 @@ jobs:
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # FFmpeg
           git -C third_party/ffmpeg fetch https://chromium.googlesource.com/chromium/third_party/ffmpeg refs/changes/84/6860784/2 && git -C third_party/ffmpeg cherry-pick FETCH_HEAD
+          # Base
+          git fetch https://chromium.googlesource.com/chromium/src refs/changes/51/7026651/3 && git cherry-pick FETCH_HEAD
+          git fetch https://chromium.googlesource.com/chromium/src refs/changes/91/7025091/3 && git cherry-pick FETCH_HEAD
   Release-Build:
     needs: Sync
     runs-on: shinx
@@ -86,4 +90,9 @@ jobs:
           set -ex
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
-          autoninja -C "$DEBUG_OUT_DIR" chrome
+          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests
+  Debug-Test:
+    needs: Debug-Build
+    uses: ./.github/workflows/base_unittests.yml
+    with:
+      build-mode: Debug

--- a/README.md
+++ b/README.md
@@ -11,5 +11,5 @@ Currently it only tests whether Debug/Release build passes.
 
 ## Plans
 
-- Run tests
+- Run more tests
 - Release binaries for Chromium and ChromeDriver.


### PR DESCRIPTION
This PR runs chromium's base_unittests for Debug build of chromium.

Currently it only runs on centrikorch as it's the most beefy machine and base does not have RVV related stuff in it.

Some tests are skipped as I don't have the bandwidth to investigate them for now.