### PR TITLE
Add cc_unittests to CI

### DIFF
--- a/.github/workflows/cc_unittests.yml
+++ b/.github/workflows/cc_unittests.yml
@@ -1,0 +1,43 @@
+name: CC Unit Tests
+run-name: CC Unit Tests
+on:
+  workflow_call:
+    inputs:
+      build-mode:
+        required: true
+        type: string
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  SRC_DIR: /home/kxxt/chromium-ci/src
+  OUT_DIR: /home/kxxt/chromium-ci/src/out/${{ inputs.build-mode }}-riscv64
+
+jobs:
+  test:
+    runs-on: rvv-incapable
+    steps:
+      - name: test
+        run: |
+            set -ex
+            cd "$OUT_DIR"
+            ./cc_unittests \
+                --test-launcher-jobs=48 \
+                --test-launcher-retry-limit=5 \
+                --test-launcher-timeout=60000 \
+                --gtest_filter=-"\
+                    `# Image is different probably due to FMA. One test also mentions underflow, which is buggy on SG2042. Not going into the details for now`\
+                    All/LayerTreeHostMaskAsBlendingPixelTest.RotatedClippedCircleUnderflow/Software_Bitmap_0:\
+                    All/LayerTreeHostMaskAsBlendingPixelTest.RotatedClippedCircle/Software_Bitmap_0:\
+                    All/LayerTreeHostFiltersPixelTest.RotatedFilter/Software:\
+                    All/LayerTreeHostFiltersPixelTest.RotatedDropShadowFilter/Software:\
+                    `# Scroll offset is different. TODO`\
+                    LayerTreeHostScrollTestCaseWithChild.DeviceScaleFactor*:\
+                    `# Failed/Crashed after a short timeout reached. The short timeout is not adjustable`\
+                    LayerTreeHostScrollTestImplScrollUnderMainThreadScrollingParent.RunSingleThread_DelegatingRenderer:\
+                    LayerTreeHostTestImageAnimationDrawRecordShader.RunMultiThread_DelegatingRenderer:\
+                    TextureLayerReleaseResourcesAfterCommit.RunSingleThread_DelegatingRenderer:\
+                    TextureLayerReleaseResourcesAfterActivate.RunSingleThread_DelegatingRenderer:\
+                    LayerTreeHostPresentationDuringAnimation.RunMultiThread_DelegatingRenderer:\
+                    LayerTreeHostAnimationTestRemoveKeyframeModel.RunSingleThread_DelegatingRenderer:\
+                    All/LayerTreeHostFiltersPixelTest.BackdropFilterRotated/SkiaGraphiteDawn
+                "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,14 @@ jobs:
           set -ex
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
-          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests
-  Debug-Test:
+          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests cc_unittests
+  base_unittests_debug:
     needs: Debug-Build
     uses: ./.github/workflows/base_unittests.yml
+    with:
+      build-mode: Debug
+  cc_unittests_debug:
+    needs: Debug-Build
+    uses: ./.github/workflows/cc_unittests.yml
     with:
       build-mode: Debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ env:
   RELEASE_OUT_DIR: /home/kxxt/Workspaces/chromium/src/out/Release-riscv64
   DEBUG_OUT_DIR: /home/kxxt/Workspaces/chromium/src/out/Debug-riscv64
   CCACHE_CPP2: 'yes'
-  CCACHE_SLOPPINESS: time_macros
+  CCACHE_SLOPPINESS: time_macros,modules
 
 jobs:
   Sync:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,9 @@ env:
   SRC_DIR: /home/kxxt/Workspaces/chromium/src
   RELEASE_OUT_DIR: /home/kxxt/Workspaces/chromium/src/out/Release-riscv64
   DEBUG_OUT_DIR: /home/kxxt/Workspaces/chromium/src/out/Debug-riscv64
-  CCACHE_CPP2: 'yes'
   CCACHE_SLOPPINESS: time_macros,modules
+  CCACHE_DEPEND: true
+  CCACHE_DIRECT: true
 
 jobs:
   Sync:


### PR DESCRIPTION
Currently there are 16 tests that failed:

```
15 tests failed:
    All/LayerTreeHostFiltersPixelTest.RotatedDropShadowFilter/Software (../../cc/trees/layer_tree_host_pixeltest_filters.cc:1018)
    All/LayerTreeHostFiltersPixelTest.RotatedFilter/Software (../../cc/trees/layer_tree_host_pixeltest_filters.cc:966)
    All/LayerTreeHostMaskAsBlendingPixelTest.RotatedClippedCircle/Software_Bitmap_0 (../../cc/trees/layer_tree_host_pixeltest_masks.cc:990)
    All/LayerTreeHostMaskAsBlendingPixelTest.RotatedClippedCircleUnderflow/Software_Bitmap_0 (../../cc/trees/layer_tree_host_pixeltest_masks.cc:1035)
    LayerTreeHostAnimationTestRemoveKeyframeModel.RunSingleThread_DelegatingRenderer (../../cc/trees/layer_tree_host_unittest_animation.cc:1642)
    LayerTreeHostPresentationDuringAnimation.RunMultiThread_DelegatingRenderer (../../cc/trees/layer_tree_host_unittest_animation.cc:1112)
    LayerTreeHostScrollTestCaseWithChild.DeviceScaleFactor15_ScrollChild (../../cc/trees/layer_tree_host_unittest_scroll.cc:808)
    LayerTreeHostScrollTestCaseWithChild.DeviceScaleFactor15_ScrollRootScrollLayer (../../cc/trees/layer_tree_host_unittest_scroll.cc:857)
    LayerTreeHostScrollTestCaseWithChild.DeviceScaleFactor1_ScrollChild (../../cc/trees/layer_tree_host_unittest_scroll.cc:792)
    LayerTreeHostScrollTestCaseWithChild.DeviceScaleFactor2_ScrollChild (../../cc/trees/layer_tree_host_unittest_scroll.cc:823)
    LayerTreeHostScrollTestCaseWithChild.DeviceScaleFactor2_ScrollRootScrollLayer (../../cc/trees/layer_tree_host_unittest_scroll.cc:874)
    LayerTreeHostScrollTestImplScrollUnderMainThreadScrollingParent.RunSingleThread_DelegatingRenderer (../../cc/trees/layer_tree_host_unittest_scroll.cc:1829)
    LayerTreeHostTestImageAnimationDrawRecordShader.RunMultiThread_DelegatingRenderer (../../cc/trees/layer_tree_host_unittest.cc:8592)
    TextureLayerReleaseResourcesAfterActivate.RunSingleThread_DelegatingRenderer (../../cc/layers/texture_layer_unittest.cc:1262)
    TextureLayerReleaseResourcesAfterCommit.RunSingleThread_DelegatingRenderer (../../cc/layers/texture_layer_unittest.cc:1238)
1 test crashed:
    All/LayerTreeHostFiltersPixelTest.BackdropFilterRotated/SkiaGraphiteDawn (../../cc/trees/layer_tree_host_pixeltest_filters.cc:723)
```

The `SkiaGraphiteDawn` test and `DelegatingRenderer` tests are failing or crashing after a short ten seconds timeout is reached.
The timeout value is hardcoded as action_timeout and cannot be updated from CLI.

The `LayerTreeHostScrollTestCaseWithChild.DeviceScaleFactor*` tests are failing because the produced scroll offset does not match the expected, which we should investigate later.

Four pixel tests are failing but this is probably because of FMA, where the implementation is correct but the test is flawed.
The image does not seem different to human eyes.