### PR TITLE
Add net_unittests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           set -ex
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
-          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests cc_unittests
+          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests cc_unittests net_unittests
   base_unittests_debug:
     needs: Debug-Build
     uses: ./.github/workflows/base_unittests.yml
@@ -100,5 +100,10 @@ jobs:
   cc_unittests_debug:
     needs: Debug-Build
     uses: ./.github/workflows/cc_unittests.yml
+    with:
+      build-mode: Debug
+  net_unittests_debug:
+    needs: Debug-Build
+    uses: ./.github/workflows/net_unittests.yml
     with:
       build-mode: Debug

--- a/.github/workflows/net_unittests.yml
+++ b/.github/workflows/net_unittests.yml
@@ -1,0 +1,37 @@
+name: net Unit Tests
+run-name: net Unit Tests
+on:
+  workflow_call:
+    inputs:
+      build-mode:
+        required: true
+        type: string
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  SRC_DIR: /home/kxxt/chromium-ci/src
+  OUT_DIR: /home/kxxt/chromium-ci/src/out/${{ inputs.build-mode }}-riscv64
+
+jobs:
+  test:
+    runs-on: rvv-incapable
+    steps:
+      - name: test
+        run: |
+            set -ex
+            cd "$OUT_DIR"
+            ./net_unittests \
+                --test-launcher-jobs=48 \
+                --test-launcher-retry-limit=5 \
+                --test-launcher-timeout=60000 \
+                --gtest_filter=-"\
+                    `# Expected failure as we mounted cross-compile artifacts via NFS, which doesn't ship vpython3 for riscv`\
+                    PythonUtils.Python3RunTime:\
+                    `# Also fails on Arch Linux x86_64 so not RISC-V related`\
+                    TrustStoreNSSTestAllowSpecifiedUserSlot.CertOnMultipleSlots:\
+                    TrustStoreNSSTestAllowSpecifiedUserSlot.SystemRootCertOnMultipleSlots:\
+                    TrustStoreNSSTestIgnoreSystemCerts.UserDbAnchorAndLeafTrustForSystemRootHonored:\
+                    TrustStoreNSSTestIgnoreSystemCerts.UserDbDistrustForSystemRootHonored:\
+                    TrustStoreNSSTestIgnoreSystemCerts.UserDbLeafTrustForSystemRootHonored:\
+                    TrustStoreNSSTestIgnoreSystemCerts.UserDbTrustForSystemRootHonored
+                "


### PR DESCRIPTION
Test summary:

```
7 tests failed:
    PythonUtils.Python3RunTime (../../net/test/python_utils_unittest.cc:35)
    TrustStoreNSSTestAllowSpecifiedUserSlot.CertOnMultipleSlots (../../net/cert/internal/trust_store_nss_unittest.cc:860)
    TrustStoreNSSTestAllowSpecifiedUserSlot.SystemRootCertOnMultipleSlots (../../net/cert/internal/trust_store_nss_unittest.cc:881)
    TrustStoreNSSTestIgnoreSystemCerts.UserDbAnchorAndLeafTrustForSystemRootHonored (../../net/cert/internal/trust_store_nss_unittest.cc:626)
    TrustStoreNSSTestIgnoreSystemCerts.UserDbDistrustForSystemRootHonored (../../net/cert/internal/trust_store_nss_unittest.cc:648)
    TrustStoreNSSTestIgnoreSystemCerts.UserDbLeafTrustForSystemRootHonored (../../net/cert/internal/trust_store_nss_unittest.cc:596)
    TrustStoreNSSTestIgnoreSystemCerts.UserDbTrustForSystemRootHonored (../../net/cert/internal/trust_store_nss_unittest.cc:576)
Tests took 952 seconds.
```

The failure of `PythonUtils.Python3RunTime` is expected as we mounted the cross-compiled artifacts over NFS.

The other 6 failing NSS tests are not RISC-V specific. They also fail on Arch Linux x86-64 thus not investigating them for now.