### PR TITLE
Add v8 cctest to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
-          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/64/7529664/5 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
   Release-Build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,11 @@ jobs:
           set -ex
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
-          autoninja -C "$RELEASE_OUT_DIR" chrome.stripped
+          autoninja -C "$RELEASE_OUT_DIR" chrome.stripped v8/test/cctest
+          # TODO: v8 cctest failed to build in debug mode
+          # Move v8 test binaries to clang_x64_v8_riscv64/
+          mv "$RELEASE_OUT_DIR"/cctest "$RELEASE_OUT_DIR"/clang_x64_v8_riscv64/
+  
   Debug-Build:
     needs: Sync
     runs-on: shinx
@@ -91,9 +95,8 @@ jobs:
           set -ex
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
-          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests cc_unittests net_unittests v8/test/cctest
-          # Move v8 test binaries to clang_x64_v8_riscv64/
-          mv "$DEBUG_OUT_DIR"/cctest "$DEBUG_OUT_DIR"/clang_x64_v8_riscv64/
+          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests cc_unittests net_unittests
+
   base_unittests_debug:
     needs: Debug-Build
     uses: ./.github/workflows/base_unittests.yml
@@ -109,8 +112,8 @@ jobs:
     uses: ./.github/workflows/net_unittests.yml
     with:
       build-mode: Debug
-  v8_tests_debug:
-    needs: Debug-Build
+  v8_tests_release:
+    needs: Release-Build
     uses: ./.github/workflows/v8_tests.yml
     with:
-      build-mode: Debug
+      build-mode: Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/64/7529664/5 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
   Release-Build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,9 @@ jobs:
           set -ex
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
-          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests cc_unittests net_unittests
+          autoninja -C "$DEBUG_OUT_DIR" chrome base_unittests cc_unittests net_unittests v8/test/cctest
+          # Move v8 test binaries to clang_x64_v8_riscv64/
+          mv "$DEBUG_OUT_DIR"/cctest "$DEBUG_OUT_DIR"/clang_x64_v8_riscv64/
   base_unittests_debug:
     needs: Debug-Build
     uses: ./.github/workflows/base_unittests.yml
@@ -105,5 +107,10 @@ jobs:
   net_unittests_debug:
     needs: Debug-Build
     uses: ./.github/workflows/net_unittests.yml
+    with:
+      build-mode: Debug
+  v8_tests_debug:
+    needs: Debug-Build
+    uses: ./.github/workflows/v8_tests.yml
     with:
       build-mode: Debug

--- a/.github/workflows/v8_tests.yml
+++ b/.github/workflows/v8_tests.yml
@@ -29,7 +29,8 @@ jobs:
               -e '^cctest/test-allocation/AlignedAllocOOM'               `# OOM handler not called. TODO` \
               -e '^cctest/test-allocation/MallocedOperatorNewOOM' \
               -e '^cctest/test-allocation/AccountingAllocatorOOM' \
-              -e '^cctest/test-jump-table-assembler/JumpTablePatchingStress' `# Appears to be the SG2042 heisenbug`\
+              -e '^cctest/test-jump-table-assembler/JumpTablePatchingStress' `# Appears to be the SG2042 heisenbug` \
+              || true
             )"
             
             if [[ -n "$unexpected" ]]; then

--- a/.github/workflows/v8_tests.yml
+++ b/.github/workflows/v8_tests.yml
@@ -1,0 +1,41 @@
+name: V8 Tests
+run-name: V8 Tests
+on:
+  workflow_call:
+    inputs:
+      build-mode:
+        required: true
+        type: string
+
+env:
+  GH_TOKEN: ${{ github.token }}
+  SRC_DIR: /home/kxxt/chromium-ci/src
+  OUT_DIR: /home/kxxt/chromium-ci/src/out/${{ inputs.build-mode }}-riscv64
+
+jobs:
+  cctest:
+    runs-on: rvv-incapable
+    steps:
+      - name: test
+        run: |
+            set -ex
+            cd "$SRC_DIR"
+            ./v8/tools/run-tests.py --outdir="$OUT_DIR/clang_x64_v8_riscv64" -j48 --json-test-results=/tmp/v8-cctest.json cctest || true
+            unexpected="$(jq -r '.results[] |select(.result != "") | .name' < /tmp/v8-cctest.json | grep -v \
+              -e '^cctest/test-run-wasm-relaxed-simd'                    `# Wasm SIMD is not supported` \
+              -e '^cctest/test-run-wasm-simd'                            `# Wasm SIMD is not supported` \
+              -e '^cctest/test-gc/RunWasmTurbofan_RefTrivialCastsStatic' `# Wasm SIMD is not supported` \
+              -e '^cctest/test-gc/RunWasmLiftoff_RefTrivialCastsStatic'  `# Wasm SIMD is not supported` \
+              -e '^cctest/test-allocation/AlignedAllocOOM'               `# OOM handler not called. TODO` \
+              -e '^cctest/test-allocation/MallocedOperatorNewOOM' \
+              -e '^cctest/test-allocation/AccountingAllocatorOOM' \
+              -e '^cctest/test-jump-table-assembler/JumpTablePatchingStress' `# Appears to be the SG2042 heisenbug`\
+            )"
+            
+            if [[ -n "$unexpected" ]]; then
+              echo "Unexpected failures: "
+              echo "$unexpected"
+              exit 1
+            fi
+
+

--- a/.github/workflows/v8_tests.yml
+++ b/.github/workflows/v8_tests.yml
@@ -20,7 +20,9 @@ jobs:
         run: |
             set -ex
             cd "$SRC_DIR"
-            ./v8/tools/run-tests.py --outdir="$OUT_DIR/clang_x64_v8_riscv64" -j48 --json-test-results=/tmp/v8-cctest.json cctest || true
+            ./v8/tools/run-tests.py --outdir="$OUT_DIR/clang_x64_v8_riscv64" \
+              --exit-after-n-failures=0 `# Don't exit on too many failures. We need to run all tests` \
+              -j48 --json-test-results=/tmp/v8-cctest.json cctest || true
             unexpected="$(jq -r '.results[] |select(.result != "") | .name' < /tmp/v8-cctest.json | grep -v \
               -e '^cctest/test-run-wasm-relaxed-simd'                    `# Wasm SIMD is not supported` \
               -e '^cctest/test-run-wasm-simd'                            `# Wasm SIMD is not supported` \

--- a/.github/workflows/v8_tests.yml
+++ b/.github/workflows/v8_tests.yml
@@ -32,6 +32,10 @@ jobs:
               -e '^cctest/test-allocation/MallocedOperatorNewOOM' \
               -e '^cctest/test-allocation/AccountingAllocatorOOM' \
               -e '^cctest/test-jump-table-assembler/JumpTablePatchingStress' `# Appears to be the SG2042 heisenbug` \
+              -e '^cctest/test-run-wasm/RunWasmLiftoff_Select_s128_parameters' `# TODO: investigate the following` \
+              -e '^cctest/test-run-wasm/RunWasmTurbofan_Select_s128_parameters' \
+              -e '^cctest/test-serialize/SnapshotCreatorNoExternalReferencesCustomFail1' \
+              -e '^cctest/test-serialize/SnapshotCreatorNoExternalReferencesCustomFail2' \
               || true
             )"
             


### PR DESCRIPTION
This PR adds V8 cctest to the weekly CI, aiming to catch bugs like https://chromium-review.googlesource.com/c/v8/v8/+/7484947

Test results:

- Expected failures with `Wasm SIMD is not supported`:

        -e '^cctest/test-run-wasm-relaxed-simd' 
        -e '^cctest/test-run-wasm-simd'                            
        -e '^cctest/test-gc/RunWasmTurbofan_RefTrivialCastsStatic' 
        -e '^cctest/test-gc/RunWasmLiftoff_RefTrivialCastsStatic' 
- 3 tests fail potentially because the OOM handler is not called, needing investigation:

        -e '^cctest/test-allocation/AlignedAllocOOM'               
        -e '^cctest/test-allocation/MallocedOperatorNewOOM' 
        -e '^cctest/test-allocation/AccountingAllocatorOOM' 
- Failing with SIGILL, need further investigation:

        -e '^cctest/test-jump-table-assembler/JumpTablePatchingStress' 

- Entered `UNREACHABLE()` code, need further investigation:

        -e '^cctest/test-serialize/SnapshotCreatorNoExternalReferencesCustomFail1' 
        -e '^cctest/test-serialize/SnapshotCreatorNoExternalReferencesCustomFail2' 

- `Liftoff bailout should not happen. Cause: v128 global`

        -e '^cctest/test-run-wasm/RunWasmLiftoff_Select_s128_parameters'
        -e '^cctest/test-run-wasm/RunWasmTurbofan_Select_s128_parameters' 