### PR TITLE
CD: fix crash in V8 and run on shinx for better upload throughput

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,8 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/47/7484947/3 && git -C v8 cherry-pick FETCH_HEAD
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/90/7498990/9 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Installer
           git fetch https://chromium.googlesource.com/chromium/src refs/changes/96/7509196/2 && git cherry-pick FETCH_HEAD

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -37,7 +37,7 @@ jobs:
             echo "should-continue=true" >> "$GITHUB_OUTPUT"
           fi
   Sync:
-    runs-on: magmar
+    runs-on: shinx
     needs: Check-Latest
     if: ${{ needs.Check-Latest.outputs.should-continue == 'true' }}
     steps:
@@ -67,7 +67,7 @@ jobs:
           git fetch https://chromium.googlesource.com/chromium/src refs/changes/96/7509196/2 && git cherry-pick FETCH_HEAD
   Release-Build:
     needs: Sync
-    runs-on: magmar
+    runs-on: shinx
     timeout-minutes: 600
     steps:
       - name: Configure (Release)
@@ -92,7 +92,7 @@ jobs:
           autoninja -C "$RELEASE_OUT_DIR" chrome.stripped chrome_sandbox.stripped chromedriver
   Packaging:
     needs: [Release-Build, Check-Latest]
-    runs-on: magmar
+    runs-on: shinx
     steps:
       - name: Debug file Packaging
         run: |
@@ -169,7 +169,7 @@ jobs:
 
   Upload:
     needs: [Packaging, Check-Latest]
-    runs-on: magmar
+    runs-on: shinx
     permissions:
       contents: write
     steps:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -89,7 +89,12 @@ jobs:
           set -ex
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
-          autoninja -C "$RELEASE_OUT_DIR" chrome.stripped chrome_sandbox.stripped chromedriver
+          autoninja -C "$RELEASE_OUT_DIR" \
+            chrome.stripped chrome_sandbox.stripped chrome_crashpad_handler.stripped \
+            libEGL.so.stripped libGLESv2.so.stripped \
+            libqt{5,6}_shim.so.stripped \
+            libvk_swiftshader.so.stripped libvulkan.so.1.stripped \
+            chromedriver
   Packaging:
     needs: [Release-Build, Check-Latest]
     runs-on: shinx
@@ -100,15 +105,8 @@ jobs:
           rm -rf -- "debug_files" 
           mkdir -p "debug_files"
         
-          # Add debug link for Chromium
-          llvm-objcopy --only-keep-debug "$RELEASE_OUT_DIR"/chrome "$RELEASE_OUT_DIR"/chromium.debug
-          llvm-objcopy --add-gnu-debuglink=chromium.debug "$RELEASE_OUT_DIR"/chrome.stripped
-          mv "$RELEASE_OUT_DIR"/chromium.debug "$RELEASE_OUT_DIR/debug_files/"
-          # For other ELFs
-          for elf in chrome_sandbox chrome_crashpad_handler libEGL.so libGLESv2.so libqt{5,6}_shim.so libvk_swiftshader.so libvulkan.so.1
+          for elf in chrome chrome_sandbox chrome_crashpad_handler libEGL.so libGLESv2.so libqt{5,6}_shim.so libvk_swiftshader.so libvulkan.so.1
           do
-            llvm-objcopy --only-keep-debug "$RELEASE_OUT_DIR/$elf" "$RELEASE_OUT_DIR/elf.debug"
-            llvm-objcopy --add-gnu-debuglink="$elf.debug" "$RELEASE_OUT_DIR/$elf.stripped"
             mv "$RELEASE_OUT_DIR/$elf.debug" "$RELEASE_OUT_DIR/debug_files/"
           done
 


### PR DESCRIPTION
- Pickup two v8 fixes to fix SIGILL crash on chromium 145
- Run workflow on shinx for better upload throughput
- Use the debug files generated by the build system instead of making our own ones.

Note that shinx will be dedicated to continuous delivery and unable to run CI workflows in the future
because for CD the deb packaging doesn't work well with the setgid bit, which is required for the CI workflow to
share artifacts over NFS.