### PR TITLE
CI: migrate to magmar

### DIFF
--- a/.github/actions/riscv64_nfs_setup/action.yml
+++ b/.github/actions/riscv64_nfs_setup/action.yml
@@ -1,0 +1,9 @@
+name: Mount NFS on RISC-V Runners
+description: 'Mount NFS on RISC-V Runners'
+
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      run: |
+        mount | grep chromium-ci || sudo mount 172.24.12.4:/var/lib/machines/chromium-ci/home/kxxt/Workspaces/chromium chromium-ci/

--- a/.github/actions/riscv64_nfs_setup/action.yml
+++ b/.github/actions/riscv64_nfs_setup/action.yml
@@ -6,4 +6,4 @@ runs:
   steps:
     - shell: bash
       run: |
-        mount | grep chromium-ci || sudo mount 172.24.12.4:/var/lib/machines/chromium-ci/home/kxxt/Workspaces/chromium chromium-ci/
+        mount | grep chromium-ci || sudo mount 172.24.12.4:/var/lib/machines/chromium-ci/home/kxxt/Workspaces/chromium /home/kxxt/chromium-ci/

--- a/.github/workflows/base_unittests.yml
+++ b/.github/workflows/base_unittests.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     runs-on: rvv-incapable
     steps:
+      - uses: actions/checkout@v5
+      - name: setup
+        uses: ./.github/actions/riscv64_nfs_setup
       - name: test
         run: |
             set -ex

--- a/.github/workflows/base_unittests.yml
+++ b/.github/workflows/base_unittests.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: rvv-incapable
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: setup
         uses: ./.github/actions/riscv64_nfs_setup
       - name: test

--- a/.github/workflows/cc_unittests.yml
+++ b/.github/workflows/cc_unittests.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     runs-on: rvv-incapable
     steps:
+      - uses: actions/checkout@v5
+      - name: setup
+        uses: ./.github/actions/riscv64_nfs_setup
       - name: test
         run: |
             set -ex

--- a/.github/workflows/cc_unittests.yml
+++ b/.github/workflows/cc_unittests.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: rvv-incapable
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: setup
         uses: ./.github/actions/riscv64_nfs_setup
       - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   Sync:
-    runs-on: shinx
+    runs-on: magmar
     steps:
       - name: Sync sources
         run: |
@@ -46,7 +46,7 @@ jobs:
           # Base
   Release-Build:
     needs: Sync
-    runs-on: shinx
+    runs-on: magmar
     timeout-minutes: 600
     steps:
       - name: Configure (Release)
@@ -75,7 +75,7 @@ jobs:
   
   Debug-Build:
     needs: Sync
-    runs-on: shinx
+    runs-on: magmar
     timeout-minutes: 600
     steps:
       - name: Configure (Debug)

--- a/.github/workflows/net_unittests.yml
+++ b/.github/workflows/net_unittests.yml
@@ -16,6 +16,9 @@ jobs:
   test:
     runs-on: rvv-incapable
     steps:
+      - uses: actions/checkout@v5
+      - name: setup
+        uses: ./.github/actions/riscv64_nfs_setup
       - name: test
         run: |
             set -ex

--- a/.github/workflows/net_unittests.yml
+++ b/.github/workflows/net_unittests.yml
@@ -16,7 +16,7 @@ jobs:
   test:
     runs-on: rvv-incapable
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: setup
         uses: ./.github/actions/riscv64_nfs_setup
       - name: test

--- a/.github/workflows/v8_tests.yml
+++ b/.github/workflows/v8_tests.yml
@@ -16,7 +16,7 @@ jobs:
   cctest:
     runs-on: rvv-incapable
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v4
       - name: setup
         uses: ./.github/actions/riscv64_nfs_setup
       - name: test

--- a/.github/workflows/v8_tests.yml
+++ b/.github/workflows/v8_tests.yml
@@ -16,6 +16,9 @@ jobs:
   cctest:
     runs-on: rvv-incapable
     steps:
+      - uses: actions/checkout@v5
+      - name: setup
+        uses: ./.github/actions/riscv64_nfs_setup
       - name: test
         run: |
             set -ex


### PR DESCRIPTION
Since shinx is now dedicated to CD because DEB packaging is not compatible with directory setgid bit,
move CI workflow to magmar instead.

We are using NFS for running tests on RISC-V boards so this change also means that the latency between
the NFS server and the RISC-V test boards are significantly lower.

