### PR TITLE
Add google api key

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -60,6 +60,7 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/71/7608971/3 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Installer
   Release-Build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -73,6 +73,7 @@ jobs:
           cd "$SRC_DIR"
           export PATH="$PWD/buildtools/linux64:$PATH"
           gn gen "$RELEASE_OUT_DIR"  --args='
+            google_api_key="${{ secrets.GOOGLE_API_KEY }}"
             cc_wrapper="ccache"
             is_official_build=true
             is_debug=false


### PR DESCRIPTION
Some features of Chromium uses Google APIs.

Add a google api key for our distributed chromium riscv64 binaries.

Added to repo secrets although technically it is not a secret.

While at it, fix a v8 build issue with 146.0.7680.153.