### PR TITLE
[CD] Cherry-pick compilation fix for 146

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           set -ex
           cd "$SRC_DIR"
+          git fetch https://chromium.googlesource.com/chromium/src refs/changes/51/7699551/2 && git cherry-pick FETCH_HEAD
           # Sandbox
           git fetch https://chromium.googlesource.com/chromium/src refs/changes/20/4935120/11 && git cherry-pick FETCH_HEAD
           # Swiftshader


### PR DESCRIPTION
Broken commit https://chromium-review.googlesource.com/c/chromium/src/+/7649841 got cherry-picked into 146 and 147.

I have opened cherry-pick CLs to fix it in 146 and 147:
- https://chromium-review.googlesource.com/c/chromium/src/+/7699551
- https://chromium-review.googlesource.com/c/chromium/src/+/7699932