### PR TITLE
CD: drop blink compilation fix since it landed in 146

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           set -ex
           cd "$SRC_DIR"
-          git fetch https://chromium.googlesource.com/chromium/src refs/changes/51/7699551/2 && git cherry-pick FETCH_HEAD
           # Sandbox
           git fetch https://chromium.googlesource.com/chromium/src refs/changes/20/4935120/11 && git cherry-pick FETCH_HEAD
           # Swiftshader


### PR DESCRIPTION
Fix https://github.com/riscv-forks/chromium-riscv/actions/runs/23829569308/job/69459901832