### PR TITLE
CD: fix the check for existing release

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,8 +30,9 @@ jobs:
           latest_stable="$(curl -s "https://chromiumdash.appspot.com/fetch_releases?channel=Stable&platform=Linux&num=1" | jq -r '.[0].version')"
 
           echo "latest-stable=${latest_stable}" >> "$GITHUB_OUTPUT"
+          echo "The latest stable version is ${latest_stable}"
 
-          if gh release view "$RELEASE_TAG" >/dev/null 2>&1; then
+          if gh release -R ${{ github.repository }} view "$RELEASE_TAG" >/dev/null 2>&1; then
             echo "should-continue=false" >> "$GITHUB_OUTPUT"
           else
             echo "should-continue=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
We do not checkout this repo in gh actions so `gh release view` will always fail and thus leading to a build regardless of whether there is an existing release for the tag.

Fix it and show the latest stable version in logs.