### PR TITLE
[CI] Fix 2026-04-27 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
-          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/67/7781567/8 && git -C v8 cherry-pick FETCH_HEAD
           git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/30/7784730/6 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
           git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/67/7781567/8 && git -C v8 cherry-pick FETCH_HEAD
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/30/7784730/6 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
   Release-Build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/67/7781567/8 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
   Release-Build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,6 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
-          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/30/7784730/6 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
           git fetch https://chromium.googlesource.com/chromium/src refs/changes/44/7790544/1 && git cherry-pick FETCH_HEAD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/30/7784730/6 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
+          git fetch https://chromium.googlesource.com/chromium/src refs/changes/44/7790544/1 && git cherry-pick FETCH_HEAD
   Release-Build:
     needs: Sync
     runs-on: magmar


### PR DESCRIPTION
- ~~Cherry-pick v8 7781567: [riscv][compiler] 10-bit ArchOpcodes fixes https://github.com/riscv-forks/chromium-riscv/actions/runs/24974008382/job/73122652001~~ (Dropped as it landed now)
  - Link: https://chromium-review.googlesource.com/c/v8/v8/+/7781567
- ~~Cherry-pick 7784730: [riscv][wasm-wide-arith] Turboshaft x64 implementation of wide add op. fixes https://github.com/riscv-forks/chromium-riscv/actions/runs/24975765175/job/73127332244?pr=28~~  (Dropped as it landed now)
  - Link: https://chromium-review.googlesource.com/c/v8/v8/+/7784730
- Cherry-pick fix for crash in base: Fix https://github.com/riscv-forks/chromium-riscv/actions/runs/24976137715/job/73135506059?pr=28
  - Link: https://chromium-review.googlesource.com/c/chromium/src/+/7790544