### PR TITLE
CI: fix v8 compilation on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           # Swiftshader
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/11/7908311/1 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
   Release-Build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
           git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/11/7908311/1 && git -C v8 cherry-pick FETCH_HEAD
-          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/54/7901154/4 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
   Release-Build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           git -C third_party/swiftshader fetch https://swiftshader.googlesource.com/SwiftShader refs/changes/29/75929/2 && git -C third_party/swiftshader cherry-pick FETCH_HEAD
           # V8
           git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/11/7908311/1 && git -C v8 cherry-pick FETCH_HEAD
+          git -C v8 fetch https://chromium.googlesource.com/v8/v8 refs/changes/54/7901154/4 && git -C v8 cherry-pick FETCH_HEAD
           # FFmpeg
           # Base
   Release-Build:


### PR DESCRIPTION
Fix 
- https://github.com/riscv-forks/chromium-riscv/actions/runs/27115052165/job/80020802351
- https://github.com/riscv-forks/chromium-riscv/actions/runs/27127911493/job/80061410131?pr=36

CL Links: 
- https://chromium-review.googlesource.com/c/v8/v8/+/7908311?usp=search
- https://chromium-review.googlesource.com/c/v8/v8/+/7901154

The second one gets reverted since it landed in Chromium mainline now.