### PR TITLE
CI: fix 2026-08-10 CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
           # FFmpeg
           # Base
           git fetch https://chromium.googlesource.com/chromium/src refs/changes/37/8129837/1 && git cherry-pick FETCH_HEAD
+          # Sysroot
+          ln -sf libutil.so.1 build/linux/debian_trixie_riscv64-sysroot/usr/lib/riscv64-linux-gnu/libutil.so
   Release-Build:
     needs: Sync
     runs-on: magmar


### PR DESCRIPTION
Fix https://github.com/riscv-forks/chromium-riscv/actions/runs/31347730341/job/93338516054

- Manually symlink libutil.so in the sysroot as a workaround. I have opened an upstream CL to fix it: https://chromium-review.googlesource.com/c/chromium/src/+/8226185.